### PR TITLE
Update to use BytecodeHelper instead of ASM's Type class

### DIFF
--- a/src/test/groovy/groovyx/ast/bytecode/BytecodeSpock.groovy
+++ b/src/test/groovy/groovyx/ast/bytecode/BytecodeSpock.groovy
@@ -179,7 +179,10 @@ class BytecodeSpock extends Specification {
         def shell = new GroovyShell()
         def methCall = shell.evaluate("""
             import groovyx.ast.bytecode.Bytecode
-            import groovyx.ast.bytecode.DummyClassWithWeirdMethod
+
+            class DummyClassWithWeirdMethod {
+                static int[] method(double[] d, String s) { [1, 2, 3] as int[] }
+            }
 
             @Bytecode
             int[] callMethod() {
@@ -564,8 +567,4 @@ class BytecodeSpock extends Specification {
     private static sizeOf2dLevel(int[][] arr) {
         arr.length==0?0:arr[0].length
     }
-}
-
-class DummyClassWithWeirdMethod {
-    static int[] method(double[] d, String s) { [1, 2, 3] as int[] }
 }

--- a/src/test/groovy/groovyx/ast/bytecode/FieldsBytecodeSpock.groovy
+++ b/src/test/groovy/groovyx/ast/bytecode/FieldsBytecodeSpock.groovy
@@ -96,11 +96,16 @@ class FieldsBytecodeSpock extends Specification {
         def result = shell.evaluate("""
             import groovyx.ast.bytecode.*
 
+            class SomePerson {
+                public String name
+                public static int age = 33
+            }
+
             @Bytecode
             def getPerson() {
-                _new "groovyx/ast/bytecode/SomePerson"
+                _new "SomePerson"
                 dup
-                invokespecial SomePerson."<init>"() >> Void
+                invokespecial SomePerson."<init>"() >> void
                 astore 1
                 aload 1
                 ldc "Guillaume"
@@ -138,7 +143,3 @@ class FieldsBytecodeSpock extends Specification {
     }
 }
 
-class SomePerson {
-    public String name
-    public static int age = 33
-}


### PR DESCRIPTION
I made an update to use Groovy's own BytecodeHelper class instead of ASM's Type class.
It's better as before it was causing issues when the referenced types were in the same compilation unit, but not fully resolved.
